### PR TITLE
Update ruby filepath in install_installer.rb

### DIFF
--- a/recipes/install_installer.rb
+++ b/recipes/install_installer.rb
@@ -73,7 +73,7 @@ if platform_family?('debian')
 
   # This may no longer be needed in OpenStudio 1.5.1 or greater. Need to verify how this breaks older versions.
   execute 'symlink-openstudio-directories' do
-    command 'cd /usr/local/lib/ruby/site_ruby/2.0.0/ && ln -sf x86_64-linux lib'
+    command 'cd /usr/local/lib/site_ruby/2.0.0/ && ln -sf x86_64-linux lib'
 
     action :nothing
     not_if { Chef::VersionConstraint.new('>= 1.5.1').include?(node[:openstudio][:version]) }


### PR DESCRIPTION
Fixing bug which causes terminal error due to ruby 2.0.0 living in usr/local/lib/site_ruby/..., not usr/local/lib/ruby/site_ruby/...

Provisioning doesn't fix it, due to the folder path having changed, (don't know why.)

See attached photo for original vagrant log with error message.
![wrong_ruby_lib_directory](https://cloud.githubusercontent.com/assets/9537073/6090811/8c448b56-ae45-11e4-9c05-75294877d76b.png)
